### PR TITLE
Update kloi check command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## [1.0.2-beta] - 2024-09-02
+**Added**
+- Added interactive mode for stack selection to `check` command
+- Added support to used `cfn-lint` to `check` command if present on host
+
+**Fixed**
+- Fixed process exit code for errors. Now the process will exit with a non-zero code if an error occurs
+- Fixed sdk error handling in `check` command
+
 ## [1.0.1-beta] - 2024-09-02
 **Added**
 - Added interactive mode for stack selection to `apply`, `delete`, `show` commands

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kloi"
-version = "1.0.1-beta"
+version = "1.0.2-beta"
 edition = "2021"
 
 

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -6,8 +6,13 @@ use clap::{arg, ArgMatches, Command};
 use colored::Colorize;
 use log;
 use std::env;
+use crate::utils;
+use tempdir::TempDir;
+use std::fs::File;
+use std::io::Write;
 
 const ABOUT: &str = r#"validate cloudformation template
+This command uses cfn-lint if present on the host, else it will use the AWS Cloudformation validation API
 "#;
 
 pub fn command() -> Command {
@@ -31,19 +36,36 @@ pub async fn handle(matches: &ArgMatches) -> Result<(), String> {
     // load config and create client
     // note: unwrap is fine here, since we've already checked if config is set above
     let conf = config::load_config_from_file(config_path.unwrap())?;
-    let stack_name = match matches.get_one::<String>("stack") {
+    let stack_name: String = match matches.get_one::<String>("stack") {
         Some(c) => {
             if let None = conf.stacks.iter().find(|s| &s.name == c) {
                 Err(format!("stack [{}] not found", c))?;
             };
-            c
+            c.to_string()
         }
-        None => return Err("stack name required, please supply using [stack]".to_string()),
+        None => {
+            let opts = conf
+                .stacks
+                .iter()
+                .map(|s| s.name.clone())
+                .collect::<Vec<String>>();
+            utils::singleselect(opts, "select stack")
+        },
     };
 
     // can be unwrapped because we already checked that the stack exists
-    let stack = conf.stacks.iter().find(|s| &s.name == stack_name).unwrap();
+    let stack = conf.stacks.iter().find(|s| &s.name == &stack_name).unwrap();
     let template = stack.generate_template()?;
+
+    if let Ok(res) = call_cfn_lint(template.clone()) {
+        if res.contains("no issues found") {
+            println!("{}", res);
+            return Ok(());
+        }
+        // return Ok result as error to retain err code
+        // on bad cfn-lint output
+        return Err(format!("\n---\n{}", res));
+    }
 
     // create client
     let region = stack.region.clone().unwrap_or("eu-west-1".to_string());
@@ -63,9 +85,9 @@ pub async fn handle(matches: &ArgMatches) -> Result<(), String> {
     match res {
         Ok(_) => {
             println!(
-                "{}\n---\n{}",
+                "{}\n---\n{} no issues found",
                 template.truecolor(96, 96, 96),
-                "template is valid".green()
+                "✔︎".green()
             );
 
             Ok(())
@@ -75,7 +97,7 @@ pub async fn handle(matches: &ArgMatches) -> Result<(), String> {
                 println!("{}", template.truecolor(96, 96, 96));
                 let err = format!(
                     "error occured while validating template: {}",
-                    sdk_err.into_err().to_string()
+                    sdk_err.into_err().meta().message().unwrap_or("unknown error")
                 );
 
                 Err(err)
@@ -85,3 +107,38 @@ pub async fn handle(matches: &ArgMatches) -> Result<(), String> {
         },
     }
 }
+
+
+// run cfn-lint on the template string as a subprocess
+fn call_cfn_lint(template: String) -> Result<String, String> {
+    
+    let (cfn_lint_path, _) = utils::sh!("which cfn-lint");
+    if cfn_lint_path.contains("not found") {
+        return Err("cfn-lint not found".to_string());
+    };
+
+    log::debug!("cfn-lint path detected: {}", cfn_lint_path.trim());
+
+    // create temporary file with template string
+    let tmp_dir = TempDir::new("kloi_check")
+        .map_err(|e| format!("failed to create temporary directory: {}", e.to_string()))?;
+    let tmp_template_path_buf = tmp_dir.path().join("template.yaml");
+    let path = tmp_template_path_buf.to_string_lossy().to_string();
+    let mut tmp_config_file = File::create(&tmp_template_path_buf)
+        .map_err(|e| format!("failed to create temporary file: {}", e.to_string()))?;
+    write!(tmp_config_file, "{}", template).unwrap();
+
+    let cmd = format!("{} {}", cfn_lint_path.trim(), path.trim());
+    log::debug!("running cfn-lint: {}", cmd);
+
+    let (stdout, stderr) = utils::sh!(cmd);
+    if stderr != "" {
+        return Err(stderr);
+    }
+
+    if stdout == "" {
+        return Ok(format!("{} no issues found", "✔︎".green()));
+    }
+
+    Ok(stdout.replace(&path, "#"))
+}   

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -630,7 +630,23 @@ macro_rules! exec_jobs {
     };
 }
 
+#[macro_export]
+macro_rules! sh {
+    ($cmd_str:expr) => {{
+        use std::process::Command;
+        let output = Command::new("sh")
+            .arg("-c")
+            .arg($cmd_str)
+            .output()
+            .expect("Failed to execute command");
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        (stdout, stderr)
+    }};
+}
+
 // make macro public
+pub(crate) use sh;
 pub(crate) use exec_jobs;
 pub(crate) use stack_request_result_handle;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ async fn main() -> Result<(), String> {
 
     if let Err(e) = r {
         log::error!("{}", e.red());
+        std::process::exit(1);
     }
 
     Ok(())


### PR DESCRIPTION
This PR adds support for using `cfn-lint` as for template validation when calling `kloi check`
`cfn-lint` will be prioritised if present.

**Added**
- Added interactive mode for stack selection to `check` command
- Added support to used `cfn-lint` to `check` command if present on host

**Fixed**
- Fixed process exit code for errors. Now the process will exit with a non-zero code if an error occurs
- Fixed sdk error handling in `check` command
